### PR TITLE
Use MutableArithmetics

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 MosekTools = "1ec41992-ff65-5c91-ac43-2df89e9693a4"
 MultivariatePolynomials = "102ac46a-7ee4-5c85-9060-abc95bfdeaa3"
+MutableArithmetics = "d8a4904e-b15c-11e9-3269-09a3773c0cb0"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 PolyJuMP = "ddf597a6-d67e-5340-b84c-e37d84115374"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
@@ -23,13 +24,14 @@ DynamicPolynomials = "~0.3.2"
 JuMP = "~0.20"
 MathOptInterface = "~0.9.1"
 MultivariatePolynomials = "~0.3.1"
+MutableArithmetics = "0.1"
 PolyJuMP = "~0.3"
 SemialgebraicSets = "~0.2"
 SumOfSquares = "~0.3"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 CSDP = "0a46da34-8e4b-519e-b418-48813639ff34"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["CSDP"]

--- a/src/MomentOpt.jl
+++ b/src/MomentOpt.jl
@@ -2,6 +2,9 @@ module MomentOpt
 
 import Reexport
 
+import MutableArithmetics
+const MA = MutableArithmetics
+
 using MultivariatePolynomials
 const MP = MultivariatePolynomials
 using SemialgebraicSets

--- a/src/relax.jl
+++ b/src/relax.jl
@@ -1,40 +1,5 @@
 export relax!, termination_status
 
-function add_prod!(p::AbstractPolynomial{JuMP.AffExpr}, q::AbstractPolynomialLike{<:Number}, args...)
-    pt = terms(p)
-    qt = terms(q)
-    pelst = iterate(pt)
-    qelst = iterate(qt)
-    r = zero(q)
-    while qelst !== nothing
-        qel, qst = qelst
-        if pelst === nothing
-            r += qel
-            qelst = iterate(qt, qst)
-        else
-            pel, pst = pelst
-            if monomial(pel) == monomial(qel)
-                JuMP.add_to_expression!(coefficient(pel), coefficient(qel), args...)
-                qelst = iterate(qt, qst)
-                pelst = iterate(pt, pst)
-            elseif monomial(pel) < monomial(qel)
-                r += qel
-                qelst = iterate(qt, qst)
-            else
-                pelst = iterate(pt, pst)
-            end
-        end
-    end
-    if iszero(nterms(r))
-        return p
-    else
-        return p + *(r, args...)
-    end
-end
-function add_prod!(p::AbstractPolynomial{JuMP.AffExpr}, q::Number, args...)
-    add_prod!(p, constantterm(q, p), args...)
-end
-
 function dual_variable(dual::JuMP.Model, momcon::MomCon, sense::MOI.OptimizationSense)
     if momcon.set isa MOI.EqualTo
         variable = @variable(dual)
@@ -79,7 +44,7 @@ function relax!(gmp::GMPModel, order::Int, optimizer::OptimizerFactory)
 
     for (momcon, variable) in zip(gmp.constraints, gmp.dref)
         for meas in measures(momcon)
-            dlhs[meas] = add_prod!(dlhs[meas], momcon.func.momdict[meas], variable)
+            dlhs[meas] = MA.add_mul!(dlhs[meas], momcon.func.momdict[meas], variable)
         end
     end
 
@@ -94,7 +59,7 @@ function relax!(gmp::GMPModel, order::Int, optimizer::OptimizerFactory)
                 obj = -obj
             end
             # Modifies dlhs[meas] but it's ok since it not used anywhere else
-            p = add_prod!(p, obj)
+            p = MA.add_mul!(p, obj)
         end
         gmp.cref[meas] = @constraint(gmp.dual, p in meas.cert, domain = meas.supp, maxdegree = 2*order)
     end


### PR DESCRIPTION
On the burgers benchmark added in https://github.com/lanl-ansi/MomentOpt.jl/pull/5, here are the timings before and after MutableArithmetics (MA) in seconds:

| Order | Before MA [s] | After MA [s] |
|-------|---------------|--------------|
| 1     | 0.126383      | 0.014443     |
| 2     | 0.132074      | 0.022544     |
| 3     | 0.138352      | 0.035078     |
| 4     | 0.141458      | 0.041759     |
| 5     | 0.226350      | 0.054297     |
| 6     | 0.440967      | 0.076973     |
| 7     | 1.127554      | 0.155279     |
| 8     | 3.088487      | 0.240168     |
| 9     | 5.016221      | 0.411574     |
| 10    | 11.754727     | 0.670018     |
| 11    | 20.357476     | 1.386744     |
| 12    | 44.614137     | 2.059797     |

We can see that this also goes with a large reduction of memory allocation:
Before MA:
```julia
julia> burgers(12)
 44.614137 seconds (13.44 M allocations: 17.344 GiB, 5.85% gc time)
```
After MA:
```julia
julia> burgers(12)
  2.059797 seconds (6.82 M allocations: 1.043 GiB, 20.51% gc time)
```

Most of the performance improvements come from https://github.com/JuliaOpt/SumOfSquares.jl/pull/130, https://github.com/JuliaAlgebra/DynamicPolynomials.jl/pull/52 and https://github.com/JuliaOpt/MathOptInterface.jl/pull/924